### PR TITLE
Added a User-Agent for WebOS phones

### DIFF
--- a/june/lib/handler.py
+++ b/june/lib/handler.py
@@ -117,7 +117,8 @@ class BaseHandler(RequestHandler, MemberMixin, StorageMixin):
 
     def is_mobile(self):
         _mobile = (r'ipod|iphone|android|blackberry|palm|nokia|symbian|'
-                   r'samsung|psp|kindle|phone|mobile|ucweb|opera mini|fennec')
+                   r'samsung|psp|kindle|phone|mobile|ucweb|opera mini|fennec|'
+                   r'webos')
         return True if re.search(_mobile, self.user_agent.lower()) else False
 
     def is_spider(self):


### PR DESCRIPTION
I have an WebOS phone (veer) have the following UA:

```
Mozilla/5.0 (webOS/2.1.2; U; en-US) AppleWebKit/532.2
(KHTML, like Gecko) Version/1.0 Safari/532.2 P160UNA/1.0
```

I also saw Pre and Pixi's here: https://developer.palm.com/content/resources/develop/developing_web_content_for_webos.html

And WebOS based TouchPad seems do not have 'webos' in its UA. See here: http://forums.webosnation.com/hp-touchpad-tips-information-resources/286212-user-agent-string.html
