### PR TITLE
Fix a wrong url in helpers.py

### DIFF
--- a/june/helpers.py
+++ b/june/helpers.py
@@ -35,7 +35,7 @@ class require_role(object):
                 return method(*args, **kwargs)
             if g.user.role == 'new':
                 flash(_('Please verify your email'), 'warn')
-                return redirect('/account/settings')
+                return redirect(url_for('account.setting'))
             if g.user.role == 'spam':
                 flash(_('You are a spammer'), 'error')
                 return redirect('/')


### PR DESCRIPTION
There is no handler for '_/account/settings_', `s` is unnecessary.
And use `url_for` may be a good choice.
