### PR TITLE
README.rst: update npm package installation instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,7 @@ Make sure you have python2.7, pip and virtualenv installed.
 
 NodeJS is also required to compile static assets. After NodeJS is installed. You need to install::
 
-    $ npm install -g stylus component uglify-js
-    $ cd assets
-    $ npm install nib
+    $ npm install -g stylus component uglify-js nib
 
 Development
 -----------


### PR DESCRIPTION
I played with original instruction that installs nib in local directory, the
result is that npm is not able to find nib package.

Install nib package in global mode to avoid this.

Signed-off-by: Wei Liu liuw@liuw.name
