### PR TITLE
Fix the typo in the settings template

### DIFF
--- a/june/_settings.py
+++ b/june/_settings.py
@@ -41,7 +41,7 @@ SQLALCHEMY_DATABASE_URI = 'sqlite:///%s' % os.path.join(
 )
 # SQLALCHEMY_POOL_SIZE = 100
 # SQLALCHEMY_POOL_TIMEOUT = 10
-# SQLALCHEMY_POOL_RECYCEL = 3600
+# SQLALCHEMY_POOL_RECYCLE = 3600
 
 #: email settings
 # MAIL_SERVER = 'smtp.gmail.com'


### PR DESCRIPTION
SQLALCHEMY_POOL_RECYCEL -> SQLALCHEMY_POOL_RECYCLE

If not fixed, there will be "MySQL has gone away" error from time to time.
