### PR TITLE
docs: fix simple typo, descibe -> describe

### DIFF
--- a/june/filters.py
+++ b/june/filters.py
@@ -104,7 +104,7 @@ class BaseRenderer(m.HtmlRenderer):
         width = 650
         height = 366
         if title:
-            # title can descibe height and width: 650 x 366
+            # title can describe height and width: 650 x 366
             pattern = r'(\d{3,4})[^\d]+(\d{3})'
             match = re.match(pattern, title)
             if match:


### PR DESCRIPTION
There is a small typo in june/filters.py.

Should read `describe` rather than `descibe`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md